### PR TITLE
add support for current mongo/nedb apis, fix package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "url": "git@github.com:louischatriot/nedb-to-mongodb.git"
   },
   "dependencies": {
-    "nedb": "latest",
-    "mongodb": "latest",
+    "nedb": "^1.8.0",
+    "mongodb": "^3.3.4",
     "commander": "~1.1.1",
     "async": "~0.2.8"
   },


### PR DESCRIPTION
Upon checking out this repo to replicate data from an nedb to a mongo db, I received many errors related to the transfer script using methods that have changed or no longer exist with current versions of the nedb/mongodb packages. So, I added support for the current mongo/nedb apis and fixed the versions for the mongo/nedb packages so the code will be stable indefinitely. 